### PR TITLE
Update build workflow for Modrinth deployment and increment mod version to 1.0.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,56 +1,69 @@
-name: Build and Release Minecraft Mod
+name: Build, Tag & Deploy Mod
 
 on:
   push:
+    branches:
+      - main
+    # This workflow also listens for tag pushes (which trigger deployment)
     tags:
-      - 'v*'  # Runs when pushing a tag like v1.0.0
-  workflow_dispatch:  # Allows manual trigger
+      - 'v*'
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
+      - name: Checkout Code
         uses: actions/checkout@v4
 
       - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: 21
 
-      - name: Grant execute permission for Gradle
-        run: chmod +x gradlew
+      # When a tag is pushed, update gradle.properties so that mod_version matches the tag.
+      - name: Update mod_version from Tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          # Extract version number (remove leading 'v')
+          version=${GITHUB_REF_NAME#v}
+          echo "Tag version: $version"
+          # Update the mod_version property in gradle.properties
+          sed -i "s/^mod_version=.*/mod_version=${version}/" gradle.properties
+          echo "Updated gradle.properties:"
+          cat gradle.properties
 
-      - name: Build the mod
+      - name: Build Mod
         run: ./gradlew build
 
-      - name: Upload Mod JAR
-        uses: actions/upload-artifact@v4
-        with:
-          name: The-Fallen-Mod
-          path: build/libs/the-fallen-*.jar  # Uploads all matching versions
-
-  release:
-    needs: build
+  tag_release:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-
+    needs: build
+    # Only run this job on pushes to the main branch (not on tag pushes)
+    if: github.ref == 'refs/heads/main'
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout Code for Tagging
+        uses: actions/checkout@v3
 
-      - name: Download built JAR
-        uses: actions/download-artifact@v3
-        with:
-          name: The-Fallen-Mod
-          path: artifacts
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: artifacts/the-fallen-*.jar
-          body: "Automated release of The Fallen Mod."
+      # Use an auto-tagging action to create a new tag.
+      - name: Auto Tag Release
+        uses: anothrNick/github-tag-action@1.36.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BUMP: patch
+          # Optionally, set a custom tag prefix if desired:
+          # TAG_PREFIX: "v"
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    # Run the deploy job only when a tag is pushed.
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout Code for Deployment
+        uses: actions/checkout@v3
+
+      - name: Publish to Modrinth via Minotaur
+        run: ./gradlew modrinth
+        env:
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ hs_err_*.log
 replay_*.log
 *.hprof
 *.jfr
+
+# environment
+
+*.env

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+	id "com.modrinth.minotaur" version "2.+"
 	id 'fabric-loom' version '1.10-SNAPSHOT'
 	id 'maven-publish'
 }
@@ -87,4 +88,33 @@ publishing {
 		// The repositories here will be used for publishing your artifact, not for
 		// retrieving dependencies.
 	}
+}
+
+modrinth {
+    // The API token is read from an environment variable for security.
+    token = System.getenv("MODRINTH_TOKEN")
+    
+    // Set your Modrinth project ID or slug.
+    projectId = "the-fallen"
+    
+    // Use the project's version (which you've set to project.mod_version) as the version number.
+    versionNumber = project.version.toString()
+    
+    // Optionally set a version name. Here it prepends a name string to the version.
+    versionName = "The Fallen v${project.version}"
+    
+    // Provide a changelog for this version.
+    changelog = "Automated release of version ${project.version}"
+    
+    // With Fabric Loom, the upload file must be the remapped jar.
+    uploadFile = tasks.remapJar
+    
+    // Specify the supported Minecraft versions. You can use your project's minecraft_version property.
+    gameVersions = [project.minecraft_version]
+    
+    // Specify the mod loader; for Fabric this is simply "fabric".
+    loaders = ["fabric"]
+    
+    // If you want to sync your project's README as the project body on Modrinth, you can do so:
+    syncBodyFrom = file("README.md").text
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.4+build.8
 loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.0.3
+mod_version=1.0.4
 maven_group=dhugs
 archives_base_name=the-fallen
 


### PR DESCRIPTION
Enhance the build workflow to support automatic tagging and deployment to Modrinth. Update the mod version to 1.0.4 and configure the necessary properties for Modrinth integration.