### PR TITLE
Add write permissions to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,12 @@
 name: Build, Tag & Deploy Mod
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:
       - main
-    # This workflow also listens for tag pushes (which trigger deployment)
     tags:
       - 'v*'
 


### PR DESCRIPTION
Grant write access to contents in the build workflow to facilitate deployment processes.