### PR TITLE
Update workflows for versioning and building

### DIFF
--- a/.github/workflows/dev-update-workflow.yml
+++ b/.github/workflows/dev-update-workflow.yml
@@ -1,14 +1,12 @@
 permissions:
   contents: write
 
-name: Update Version, Build & Tag Release
+name: Update Version on Dev Branch
 
 on:
   push:
     branches:
-      - main
       - dev
-  workflow_dispatch:
 
 jobs:
   update_version:
@@ -43,34 +41,3 @@ jobs:
           git commit -m "Bump mod_version to ${{ steps.bump_version.outputs.new_version }} [skip version update]"
           git remote set-url origin https://${{ secrets.GITHUB_TOKEN }}@github.com/declanhuggins/the-fallen.git
           git push origin HEAD:${{ github.ref }}
-
-  build:
-    runs-on: ubuntu-latest
-    needs: update_version
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 21
-
-      - name: Build Mod
-        run: ./gradlew build
-
-  tag_release:
-    runs-on: ubuntu-latest
-    needs: [build, update_version]
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout Code for Tagging
-        uses: actions/checkout@v3
-
-      - name: Auto Tag Release
-        uses: anothrNick/github-tag-action@1.36.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CUSTOM_TAG: "v${{ needs.update_version.outputs.new_version }}"

--- a/.github/workflows/main-build-tag-workflow.yml
+++ b/.github/workflows/main-build-tag-workflow.yml
@@ -1,0 +1,42 @@
+permissions:
+  contents: write
+
+name: Build & Tag on Main Branch
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Build Mod
+        run: ./gradlew build
+
+  tag_release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout Code for Tagging
+        uses: actions/checkout@v3
+
+      - name: Auto Tag Release
+        uses: anothrNick/github-tag-action@1.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Let the action determine the new tag based on the commit history.
+          # You can also force a specific tag using CUSTOM_TAG if desired.
+          DEFAULT_BUMP: patch
+          WITH_V: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.4+build.8
 loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.1.4
+mod_version=1.2.0
 maven_group=dhugs
 archives_base_name=the-fallen
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.4+build.8
 loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.2.0
+mod_version=1.2.1
 maven_group=dhugs
 archives_base_name=the-fallen
 


### PR DESCRIPTION
Remove the outdated release workflow and introduce new workflows for version updates on the 'dev' branch and builds on the 'main' branch. Bump the mod version to 1.2.1.