### PR TITLE
Refactor GitHub workflows and update mod_version

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -1,15 +1,17 @@
 permissions:
   contents: write
 
-name: Deploy on Tag
+name: Deploy on Release Workflow Completion
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_run:
+    workflows: ["Build & Tag on Main Branch"]
+    types:
+      - completed
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code for Deployment

--- a/.github/workflows/main-build-tag-workflow.yml
+++ b/.github/workflows/main-build-tag-workflow.yml
@@ -32,11 +32,15 @@ jobs:
       - name: Checkout Code for Tagging
         uses: actions/checkout@v3
 
+      - name: Read mod_version from gradle.properties
+        id: read_version
+        run: |
+          version=$(grep "^mod_version=" gradle.properties | cut -d'=' -f2)
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "mod_version: $version"
+          
       - name: Auto Tag Release
         uses: anothrNick/github-tag-action@1.36.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Let the action determine the new tag based on the commit history.
-          # You can also force a specific tag using CUSTOM_TAG if desired.
-          DEFAULT_BUMP: patch
-          WITH_V: true
+          CUSTOM_TAG: "v${{ steps.read_version.outputs.version }}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.4+build.8
 loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.3.1
+mod_version=1.4.0
 maven_group=dhugs
 archives_base_name=the-fallen
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.4+build.8
 loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.3.0
+mod_version=1.3.1
 maven_group=dhugs
 archives_base_name=the-fallen
 


### PR DESCRIPTION
Refactor the GitHub workflows to remove deprecated processes and enhance the deployment strategy by introducing a new workflow for automated deployment upon release completion. Update the mod_version to 1.4.0.