### PR TITLE
Update deployment workflow and Gradle configuration for version 2.0.0

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -17,6 +17,12 @@ jobs:
       - name: Checkout Code for Deployment
         uses: actions/checkout@v3
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 21
+
       - name: Publish to Modrinth via Minotaur
         run: ./gradlew modrinth
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ modrinth {
     changelog = "Automated release of version ${project.version}"
     
     // With Fabric Loom, the upload file must be the remapped jar.
-    uploadFile = tasks.remapJar
+    uploadFile = tasks.named("remapJar").get()
     
     // Specify the supported Minecraft versions. You can use your project's minecraft_version property.
     gameVersions = [project.minecraft_version]
@@ -117,4 +117,8 @@ modrinth {
     
     // If you want to sync your project's README as the project body on Modrinth, you can do so:
     syncBodyFrom = file("README.md").text
+
+	dependencies {
+        required.project "fabric-api"
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.4+build.8
 loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.4.0
+mod_version=2.0.0
 maven_group=dhugs
 archives_base_name=the-fallen
 


### PR DESCRIPTION
Enhance the deployment workflow by adding JDK 21 setup and update Gradle configuration for the new version, including changes to the Modrinth upload process and project dependencies.