### PR TITLE
Prepare and copy main jar artifact in build workflow

### DIFF
--- a/.github/workflows/main-build-tag-workflow.yml
+++ b/.github/workflows/main-build-tag-workflow.yml
@@ -25,11 +25,22 @@ jobs:
       - name: Build Mod
         run: ./gradlew build
 
+      - name: Prepare Main Jar Artifact
+        run: |
+          # Find the main jar (exclude any -sources.jar)
+          MAIN_JAR=$(ls ./build/libs/the-fallen-*.jar | grep -v sources)
+          echo "Main jar found: $MAIN_JAR"
+          mkdir -p artifact
+          cp "$MAIN_JAR" artifact/
+          echo "Artifact folder contents:"
+          ls -al artifact
+        shell: bash
+
       - name: Upload Jar Artifact
         uses: actions/upload-artifact@v4
         with:
           name: the-fallen-jar
-          path: ./build/libs/the-fallen-*.jar
+          path: artifact
 
   tag_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a step in the build workflow to prepare and copy the main jar artifact to a designated folder for easier access during the upload process.